### PR TITLE
xnoise support

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -25,7 +25,8 @@
     "rhythmbox3",
     "spotify",
     "tomahawk",
-    "xbmc"
+    "xbmc",
+    "xnoise"
 ],
 "support_seek": [
     "amarok",
@@ -39,7 +40,8 @@
     "rhythmbox",
     "rhythmbox3",
     "spotify",
-    "tomahawk"
+    "tomahawk",
+    "xnoise"
 ],
 
 "use_metadata_pref":false,


### PR DESCRIPTION
Added support for xnoise (media player for gtk+, http://code.google.com/p/xnoise/). Verified that the extension works in the same way as it does for the other supported players (tested against Amarok). Note: Toggling the shuffle switch also enables repeat, since xnoise's shuffle mode implies repeat. Therefore, this is correct behavior even if it may look strange.
